### PR TITLE
Add Net-Hlld to list of clients.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Clients
 
 Here is a list of known client implementations:
 
+* Perl: https://github.com/Weborama/Net-Hlld
 * Python : https://github.com/armon/pyhlld
 * Ruby: https://github.com/mdlayher/rb-hlld
 


### PR DESCRIPTION
Hi,

I wrote a Perl client for hlld, featuring optional client-side hashing of long keys and not much else.

Hope this is of interest.
