### PR TITLE
Fixing import of sys/errno

### DIFF
--- a/src/bitmap.c
+++ b/src/bitmap.c
@@ -6,7 +6,7 @@
 #include <fcntl.h>
 #include <strings.h>
 #include <sys/mman.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/stat.h>
 #include <syslog.h>
 #include "bitmap.h"


### PR DESCRIPTION
Fixing an import of sys/errno that prevents hlld from compiling on Alpine Linux.