### PR TITLE
docs: fix simple typo, unforunate -> unfortunate

### DIFF
--- a/src/set_manager.c
+++ b/src/set_manager.c
@@ -1110,7 +1110,7 @@ static void* setmgr_thread_main(void *in) {
         /*
          * Mark any pending deletes so that create does not allow
          * a set to be created before we manage to call delete_old_versions.
-         * There is an unforunate race that can happen if a client
+         * There is an unfortunate race that can happen if a client
          * does a create/drop/create cycle, where the create/drop are
          * reflected in the set_map, and thus the second create is allowed
          * BEFORE we have had a chance to actually handle the delete.


### PR DESCRIPTION
There is a small typo in src/set_manager.c.

Should read `unfortunate` rather than `unforunate`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md